### PR TITLE
Fixing redirection for windows-enrollment-company-portal

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -16,7 +16,7 @@
             "redirect_document_id": false
         },
         {
-            "source_path": "memdocs/intune/user-help/windows-enrollment-company.md",  
+            "source_path": "memdocs/intune/user-help/windows-enrollment-company-portal.md",  
             "redirect_url": "/mem/intune/user-help/using-your-windows-device-with-intune",  
             "redirect_document_id": true 
         },


### PR DESCRIPTION
The Windows Company Portal used to use the https://docs.microsoft.com/en-us/mem/intune/user-help/windows-enrollment-company-portal link and we noticed it now leads to a 404 page. When reviewing this file, it looks like the source_path here is missing the -portal, unless there was previously another link that was just windows-enrollment-company. If so, this is the wrong change and I'll just need to add a separate redirection item. Let me know if that is the case.